### PR TITLE
Fix dpkg-source: warning: can't parse dependency dwarves (>=1.17-1) (>= 1.21)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -152,6 +152,7 @@ then
 else
   sed -i -re "s/(^linux) \(([0-9]+\.[0-9]+\.[0-9]+)-([0-9]+)\.[0-9]+\) ([^;]*)(.*)/linux (${kver:1}-${abinum}.${debversion}) ${series}\5/" debian.master/changelog
 fi
+sed -i -re 's/dwarves \[/dwarves (>=1.21) \[/g' debian.master/control.stub.in
 
 if [ "$flavour" != "none" ]
 then

--- a/build.sh
+++ b/build.sh
@@ -152,8 +152,6 @@ then
 else
   sed -i -re "s/(^linux) \(([0-9]+\.[0-9]+\.[0-9]+)-([0-9]+)\.[0-9]+\) ([^;]*)(.*)/linux (${kver:1}-${abinum}.${debversion}) ${series}\5/" debian.master/changelog
 fi
-sed -i -re 's/dwarves/dwarves (>=1.17-1)/g' debian.master/control.stub.in
-
 
 if [ "$flavour" != "none" ]
 then


### PR DESCRIPTION
Fix error - dpkg-source: warning: can't parse dependency dwarves (>=1.17-1) (>= 1.21)
Resolves #14