### PR TITLE
Fix Docker 20.04 builds (at least locally)

### DIFF
--- a/Dockerfile.focal
+++ b/Dockerfile.focal
@@ -22,10 +22,10 @@ RUN set -x \
     dh-strip-nondeterminism distro-info-data dwz file gettext gettext-base groff-base \
     intltool-debian libarchive-zip-perl libbsd0 libcroco3 libdebhelper-perl libelf1 libexpat1 \
     libfile-stripnondeterminism-perl libglib2.0-0 libicu66 libmagic-mgc libmagic1 libmpdec2 \
-    libpipeline1 libpython3-stdlib libpython3.8-minimal libpython3.8-stdlib libsigsegv2 \
+    libpipeline1 libpython3-stdlib libpython3.9-minimal libpython3.9-stdlib libsigsegv2 \
     libssl1.1 libsub-override-perl libtool libuchardet0 libxml2 \
     lsb-release m4 man-db mime-support po-debconf python-apt-common python3 python3-apt \
-    python3-minimal python3.8 python3.8-minimal sbsigntool tzdata dctrl-tools kernel-wedge \
+    python3-minimal python3.9 python3.9-minimal sbsigntool tzdata dctrl-tools kernel-wedge \
     libncurses-dev gawk flex bison openssl libssl-dev dkms libelf-dev libudev-dev libpci-dev \
     libiberty-dev autoconf bc build-essential libusb-1.0-0-dev libhidapi-dev curl wget \
     cpio makedumpfile libcap-dev libnewt-dev libdw-dev rsync gnupg2 ca-certificates\


### PR DESCRIPTION
The error in Focal builds was occurring because of this error:
```py
Traceback (most recent call last):
  File "/<<PKGBUILDDIR>>/debian/scripts/misc/kconfig/annotations.py", line 79, in _parse_body
    entry['policy'] |= literal_eval(m.group(1))
TypeError: unsupported operand type(s) for |=: 'dict' and 'dict'
```
This syntax for dict union assignments was added in CPython 3.9, and the docker container was using 3.8. When I switched these libraries from 3.8 to 3.9 locally, it worked. I'm not sure how to reconfigure launchpad to use 3.9 though, so that might need to be done by TuxInvader.